### PR TITLE
Improve support for custom error handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In order to properly `401` errors:
 fastify.setErrorHandler(function (err, req, reply) {
   if (err.statusCode === 401) {
     // this was unauthorized! Display the correct page/message.
-    reply.send({ was: 'unauthorized' })
+    reply.code(401).send({ was: 'unauthorized' })
     return
   }
   reply.send(err)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ fastify.after(() => {
 })
 ```
 
+### Custom error handler
+
+On failed authentication, *fastify-basic-auth* will call the Fastify
+[generic error
+handler](https://www.fastify.io/docs/latest/Server/#seterrorhandler) with an error.
+*fastify-basic-auth* sets the `err.statusCode` property to `401`.
+
+In order to properly `401` errors:
+
+```js
+fastify.setErrorHandler(function (err, req, reply) {
+  if (err.statusCode === 401) {
+    // this was unauthorized! Display the correct page/message.
+    reply.send({ was: 'unauthorized' })
+    return
+  }
+  reply.send(err)
+})
+```
+
 ## Options
 
 ### `validate` <Function> (required)

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fp = require('fastify-plugin')
 const auth = require('basic-auth')
+const { Unauthorized } = require('http-errors')
 
 function basicPlugin (fastify, opts, next) {
   if (typeof opts.validate !== 'function') {
@@ -19,7 +20,7 @@ function basicPlugin (fastify, opts, next) {
     }
     var credentials = auth(req)
     if (credentials == null) {
-      done(new Error('Missing or bad formatted authorization header'))
+      done(new Unauthorized('Missing or bad formatted authorization header'))
     } else {
       var result = validate(credentials.name, credentials.pass, req, reply, done)
       if (result && typeof result.then === 'function') {
@@ -29,7 +30,10 @@ function basicPlugin (fastify, opts, next) {
 
     function done (err) {
       if (err !== undefined) {
-        reply.code(401)
+        // We set the status code to be 401 if it is not set
+        if (!err.statusCode) {
+          err.statusCode = 401
+        }
         next(err)
       } else {
         next()

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "basic-auth": "^2.0.0",
-    "fastify-plugin": "^1.0.1"
+    "fastify-plugin": "^1.0.1",
+    "http-errors": "^1.7.2"
   }
 }


### PR DESCRIPTION
This is an alternative implementation to solve the same issue of #8. The main difference is that we keep calling `next(err)`, however we set the `err.statusCode` to 401 now instead of calling `reply.code(401)`. In this way a user can check that property in the custom error handler.

Fixes #8. 