### PR TITLE
chore: lint code and update deps to pass tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # fastify-basic-auth
 
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)  ![CI](https://github.com/fastify/fastify-basic-auth/workflows/CI/badge.svg)
+![CI](https://github.com/fastify/fastify-basic-auth/workflows/CI/badge.svg?branch=master)
+[![NPM version](https://img.shields.io/npm/v/fastify-basic-auth.svg?style=flat)](https://www.npmjs.com/package/fastify-basic-auth)
+[![Known Vulnerabilities](https://snyk.io/test/github/fastify/fastify-basic-auth/badge.svg)](https://snyk.io/test/github/fastify/fastify-basic-auth)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
  A simple basic auth plugin for Fastify.
 

--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ function basicPlugin (fastify, opts, next) {
     if (authenticateHeader) {
       reply.header(authenticateHeader.key, authenticateHeader.value)
     }
-    var credentials = auth(req)
+    const credentials = auth(req)
     if (credentials == null) {
       done(new Unauthorized('Missing or bad formatted authorization header'))
     } else {
-      var result = validate(credentials.name, credentials.pass, req, reply, done)
+      const result = validate(credentials.name, credentials.pass, req, reply, done)
       if (result && typeof result.then === 'function') {
         result.then(done, done)
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-basic-auth#readme",
   "devDependencies": {
+    "@types/node": "^14.14.34",
     "fastify": "^3.0.0",
     "fastify-auth": "^1.0.0",
     "standard": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fastify-auth": "^1.0.0",
     "standard": "^16.0.1",
     "tap": "^14.10.7",
-    "tsd": "^0.11.0"
+    "tsd": "^0.14.0"
   },
   "dependencies": {
     "basic-auth": "^2.0.1",


### PR DESCRIPTION
- Linted with Standard
- Added `@types/node` dev dependency to allow for tsd to be bumped from 0.11.0 to 0.14.0, closing #27 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
