### PR TITLE
Only send www-authenticate for 401. Make realm dynamic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ fastify.register(require('fastify-basic-auth'), {
 })
 ```
 
+The `realm` key could also be a function:
+
+```js
+fastify.register(require('fastify-basic-auth'), {
+  validate,
+  authenticate: {
+    realm(req) {
+      return 'example' // WWW-Authenticate: Basic realm="example"
+    }
+  }
+})
+```
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -57,10 +57,10 @@ function getAuthenticateHeader (authenticate) {
       case 'boolean':
         return 'Basic'
       case 'string':
-        return `Basic realm="${realm}"` 
+        return `Basic realm="${realm}"`
       case 'function':
         return function (req) {
-          return `Basic realm="${realm(req)}"` 
+          return `Basic realm="${realm(req)}"`
         }
     }
   }

--- a/index.js
+++ b/index.js
@@ -4,19 +4,21 @@ const fp = require('fastify-plugin')
 const auth = require('basic-auth')
 const { Unauthorized } = require('http-errors')
 
-function basicPlugin (fastify, opts, next) {
+async function basicPlugin (fastify, opts) {
   if (typeof opts.validate !== 'function') {
-    return next(new Error('Basic Auth: Missing validate function'))
+    throw new Error('Basic Auth: Missing validate function')
   }
-  const authenticateHeader = getAuthenticateHeader(opts.authenticate, next)
+  const authenticateHeader = getAuthenticateHeader(opts.authenticate)
   const validate = opts.validate.bind(fastify)
   fastify.decorate('basicAuth', basicAuth)
 
-  next()
-
   function basicAuth (req, reply, next) {
-    if (authenticateHeader) {
-      reply.header(authenticateHeader.key, authenticateHeader.value)
+    switch (typeof authenticateHeader) {
+      case 'string':
+        reply.header('WWW-Authenticate', authenticateHeader)
+        break
+      case 'function':
+        reply.header('WWW-Authenticate', authenticateHeader(req))
     }
     const credentials = auth(req)
     if (credentials == null) {
@@ -42,25 +44,28 @@ function basicPlugin (fastify, opts, next) {
   }
 }
 
-function getAuthenticateHeader (authenticate, next) {
+function getAuthenticateHeader (authenticate) {
   if (!authenticate) return false
   if (authenticate === true) {
-    return {
-      key: 'WWW-Authenticate',
-      value: 'Basic'
-    }
+    return 'Basic'
   }
   if (typeof authenticate === 'object') {
-    const realm = (authenticate.realm && typeof authenticate.realm === 'string')
-      ? authenticate.realm
-      : ''
-    return {
-      key: 'WWW-Authenticate',
-      value: 'Basic' + (realm ? ` realm="${realm}"` : '')
+    const realm = authenticate.realm
+    switch (typeof realm) {
+      case 'undefined':
+        return 'Basic'
+      case 'boolean':
+        return 'Basic'
+      case 'string':
+        return `Basic realm="${realm}"` 
+      case 'function':
+        return function (req) {
+          return `Basic realm="${realm(req)}"` 
+        }
     }
   }
 
-  next(new Error('Basic Auth: Invalid authenticate option'))
+  throw new Error('Basic Auth: Invalid authenticate option')
 }
 
 module.exports = fp(basicPlugin, {

--- a/index.js
+++ b/index.js
@@ -13,13 +13,6 @@ async function basicPlugin (fastify, opts) {
   fastify.decorate('basicAuth', basicAuth)
 
   function basicAuth (req, reply, next) {
-    switch (typeof authenticateHeader) {
-      case 'string':
-        reply.header('WWW-Authenticate', authenticateHeader)
-        break
-      case 'function':
-        reply.header('WWW-Authenticate', authenticateHeader(req))
-    }
     const credentials = auth(req)
     if (credentials == null) {
       done(new Unauthorized('Missing or bad formatted authorization header'))
@@ -35,6 +28,17 @@ async function basicPlugin (fastify, opts) {
         // We set the status code to be 401 if it is not set
         if (!err.statusCode) {
           err.statusCode = 401
+        }
+
+        if (err.statusCode === 401) {
+          switch (typeof authenticateHeader) {
+            case 'string':
+              reply.header('WWW-Authenticate', authenticateHeader)
+              break
+            case 'function':
+              reply.header('WWW-Authenticate', authenticateHeader(req))
+              break
+          }
         }
         next(err)
       } else {

--- a/test.js
+++ b/test.js
@@ -165,7 +165,7 @@ test('Basic with promises - 401', t => {
 })
 
 test('WWW-Authenticate (authenticate: true)', t => {
-  t.plan(3)
+  t.plan(6)
 
   const fastify = Fastify()
   const authenticate = true
@@ -192,19 +192,28 @@ test('WWW-Authenticate (authenticate: true)', t => {
 
   fastify.inject({
     url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['www-authenticate'], 'Basic')
+    t.equal(res.statusCode, 401)
+  })
+
+  fastify.inject({
+    url: '/',
     method: 'GET',
     headers: {
       authorization: basicAuthHeader('user', 'pwd')
     }
   }, (err, res) => {
-    t.equal(res.headers['www-authenticate'], 'Basic')
     t.error(err)
+    t.equal(res.headers['www-authenticate'], undefined)
     t.equal(res.statusCode, 200)
   })
 })
 
 test('WWW-Authenticate Realm (authenticate: {realm: "example"})', t => {
-  t.plan(3)
+  t.plan(6)
 
   const fastify = Fastify()
   const authenticate = { realm: 'example' }
@@ -231,13 +240,22 @@ test('WWW-Authenticate Realm (authenticate: {realm: "example"})', t => {
 
   fastify.inject({
     url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['www-authenticate'], 'Basic realm="example"')
+    t.equal(res.statusCode, 401)
+  })
+
+  fastify.inject({
+    url: '/',
     method: 'GET',
     headers: {
       authorization: basicAuthHeader('user', 'pwd')
     }
   }, (err, res) => {
     t.error(err)
-    t.equal(res.headers['www-authenticate'], 'Basic realm="example"')
+    t.equal(res.headers['www-authenticate'], undefined)
     t.equal(res.statusCode, 200)
   })
 })
@@ -572,7 +590,7 @@ test('Invalid options (authenticate)', t => {
 })
 
 test('Invalid options (authenticate realm)', t => {
-  t.plan(3)
+  t.plan(6)
 
   const fastify = Fastify()
   fastify
@@ -599,19 +617,28 @@ test('Invalid options (authenticate realm)', t => {
 
   fastify.inject({
     url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['www-authenticate'], 'Basic')
+    t.equal(res.statusCode, 401)
+  })
+
+  fastify.inject({
+    url: '/',
     method: 'GET',
     headers: {
       authorization: basicAuthHeader('user', 'pwd')
     }
   }, (err, res) => {
     t.error(err)
-    t.equal(res.headers['www-authenticate'], 'Basic')
+    t.equal(res.headers['www-authenticate'], undefined)
     t.equal(res.statusCode, 200)
   })
 })
 
 test('Invalid options (authenticate realm = undefined)', t => {
-  t.plan(3)
+  t.plan(6)
 
   const fastify = Fastify()
   fastify
@@ -638,19 +665,28 @@ test('Invalid options (authenticate realm = undefined)', t => {
 
   fastify.inject({
     url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['www-authenticate'], 'Basic')
+    t.equal(res.statusCode, 401)
+  })
+
+  fastify.inject({
+    url: '/',
     method: 'GET',
     headers: {
       authorization: basicAuthHeader('user', 'pwd')
     }
   }, (err, res) => {
     t.error(err)
-    t.equal(res.headers['www-authenticate'], 'Basic')
+    t.equal(res.headers['www-authenticate'], undefined)
     t.equal(res.statusCode, 200)
   })
 })
 
 test('WWW-Authenticate Realm (authenticate: {realm (req) { }})', t => {
-  t.plan(4)
+  t.plan(7)
 
   const fastify = Fastify()
   const authenticate = {
@@ -682,13 +718,22 @@ test('WWW-Authenticate Realm (authenticate: {realm (req) { }})', t => {
 
   fastify.inject({
     url: '/',
+    method: 'GET'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['www-authenticate'], 'Basic realm="root"')
+    t.equal(res.statusCode, 401)
+  })
+
+  fastify.inject({
+    url: '/',
     method: 'GET',
     headers: {
       authorization: basicAuthHeader('user', 'pwd')
     }
   }, (err, res) => {
-    t.equal(res.headers['www-authenticate'], 'Basic realm="root"')
     t.error(err)
+    t.equal(res.headers['www-authenticate'], undefined)
     t.equal(res.statusCode, 200)
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Following up from https://github.com/fastify/fastify-basic-auth/pull/39#discussion_r628159645, I refactored a good part of the library.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
