### PR TITLE
feat(issue-47): add support for custom auth header

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ fastify.register(require('fastify-basic-auth'), {
 })
 ```
 
+### `headerName` <String> (optional, default: undefined)
+
+When supplied, the `headerName` option will configure the plugin to parse the basic auth credentials from the given header name, rather than the default `Authorization` header.
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ export interface FastifyBasicAuthOptions {
     done: (err?: Error) => void
   ): void | Promise<void>;
   authenticate?: boolean | { realm: string };
+  headerName?: string;
 }
 
 declare const fastifyBasicAuth: FastifyPlugin<FastifyBasicAuthOptions>

--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ async function basicPlugin (fastify, opts) {
   fastify.decorate('basicAuth', basicAuth)
 
   function basicAuth (req, reply, next) {
-    const credentials = auth(req)
+    const credentials = opts.headerName
+      ? auth.parse(req.headers[opts.headerName])
+      : auth(req)
     if (credentials == null) {
       done(new Unauthorized('Missing or bad formatted authorization header'))
     } else {


### PR DESCRIPTION
Implements the feature requested in: https://github.com/fastify/fastify-basic-auth/issues/47

Follows the suggestion in [basic-auth NPM docs](https://www.npmjs.com/package/basic-auth#example) 

> A header string from any other location can also be parsed with auth.parse


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
