### PR TITLE
feat: add header option (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ fastify.register(require('fastify-basic-auth'), {
 })
 ```
 
+### `header` String (optional)
+
+When supplied, the header option is the name of the header to get
+credentials from for validation.
+
+```js
+fastify.register(require('fastify-basic-auth'), {
+  validate,
+  header: 'x-forwarded-authorization'
+})
+```
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ export interface FastifyBasicAuthOptions {
     done: (err?: Error) => void
   ): void | Promise<void>;
   authenticate?: boolean | { realm: string };
+  header?: string;
 }
 
 declare const fastifyBasicAuth: FastifyPlugin<FastifyBasicAuthOptions>

--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@ async function basicPlugin (fastify, opts) {
     throw new Error('Basic Auth: Missing validate function')
   }
   const authenticateHeader = getAuthenticateHeader(opts.authenticate)
+  const header = (opts.header && opts.header.toLowerCase()) || 'authorization'
+
   const validate = opts.validate.bind(fastify)
   fastify.decorate('basicAuth', basicAuth)
 
   function basicAuth (req, reply, next) {
-    const credentials = auth(req)
+    const credentials = auth.parse(req.headers[header])
     if (credentials == null) {
       done(new Unauthorized('Missing or bad formatted authorization header'))
     } else {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -17,7 +17,8 @@ app.register(fastifyBasicAuth, {
     expectType<string>(password)
     expectType<FastifyRequest>(req)
     expectType<FastifyReply>(reply)
-  }
+  },
+  header: 'x-forwarded-authorization'
 })
 
 app.register(fastifyBasicAuth, {


### PR DESCRIPTION
      Allow for a 'header' property to be specified in the options object.
      If present use the value specified as the name of the header from
      which to extract credentials for validation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
