### PR TITLE
Controversial: Avoid repeated GH-action updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Avoids noise + clarifies release notes, as [`2.2.0`](https://github.com/fastify/fastify-basic-auth/releases/tag/v2.2.0) looked like in the attached screenshot

I realise this is probably an unwanted change, but I just want to throw it out there.

![Skärmavbild 2021-11-16 kl  15 13 29](https://user-images.githubusercontent.com/34457/142001637-73759d1d-52fc-43b2-b5e1-f87af31bbc17.png)