### PR TITLE
Added Error to return type of async validator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export interface FastifyBasicAuthOptions {
     req: FastifyRequest,
     reply: FastifyReply,
     done: (err?: Error) => void
-  ): void | Promise<void>;
+  ): void | Promise<void|Error>;
   authenticate?: boolean | { realm: string };
   header?: string;
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,6 +19,7 @@ app.register(fastifyBasicAuth, {
     expectType<FastifyRequest>(req)
     expectType<FastifyReply>(reply)
     expectType<FastifyInstance>(this)
+    return new Error("unauthorized")
   },
   header: 'x-forwarded-authorization'
 })

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,6 +12,19 @@ import fastifyBasicAuth from '.'
 
 const app = fastify()
 
+//validation ok
+app.register(fastifyBasicAuth, {
+  validate: async function validatePromise (username, password, req, reply) {
+    expectType<string>(username)
+    expectType<string>(password)
+    expectType<FastifyRequest>(req)
+    expectType<FastifyReply>(reply)
+    expectType<FastifyInstance>(this)
+  },
+  header: 'x-forwarded-authorization'
+})
+
+//validation failure
 app.register(fastifyBasicAuth, {
   validate: async function validatePromise (username, password, req, reply) {
     expectType<string>(username)
@@ -23,6 +36,8 @@ app.register(fastifyBasicAuth, {
   },
   header: 'x-forwarded-authorization'
 })
+
+
 
 app.register(fastifyBasicAuth, {
   validate: function validateCallback (username, password, req, reply, done) {


### PR DESCRIPTION
This PR changes the Typescript definition.
When using an async validator, errors are either throwed or returned.
The initial typing only considered the case when Error where throwed. This PR add a union type including Error on the returned Promise.
The test is also modified by returning an Error

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
