### PR TITLE
fix(index): do not set header if `authenticate` is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,10 @@ async function fastifyBasicAuth (fastify, opts) {
         }
 
         if (err.statusCode === 401) {
-          reply.header('WWW-Authenticate', authenticateHeader(req))
+          const header = authenticateHeader(req)
+          if (header) {
+            reply.header('WWW-Authenticate', header)
+          }
         }
         next(err)
       } else {


### PR DESCRIPTION
The [readme states](https://github.com/fastify/fastify-basic-auth?tab=readme-ov-file#authenticate-booleanobject-optional-default-false) that if `authenticate: false` is set then the response header will not be set, however this is not the case.
It sets the header to "false" as [caught in these test failures](https://github.com/Fdawgs/yh-community-contacts-api/actions/runs/7059876862/job/19218330685?pr=921).

This PR ensures no header is added  if `authenticate: false` is set.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
