### PR TITLE
refactor(index): enforce strict regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,15 +41,15 @@ const token68 = '([\\w.~+/-]+=*)'
 /**
  * @see https://datatracker.ietf.org/doc/html/rfc7235#appendix-C
  */
-const credentialsStrictRE = new RegExp(`^${authScheme} ${token68}$`, 'i')
+const credentialsStrictRE = new RegExp(`^${authScheme} ${token68}$`, 'iu')
 
-const credentialsLaxRE = new RegExp(`^${BWS}*${authScheme}${BWS}+${token68}${BWS}*$`, 'i')
+const credentialsLaxRE = new RegExp(`^${BWS}*${authScheme}${BWS}+${token68}${BWS}*$`, 'iu')
 
 /**
  * @see https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
  */
 // eslint-disable-next-line no-control-regex
-const controlRE = /[\x00-\x1F\x7F]/
+const controlRE = /[\x00-\x1F\x7F]/u
 
 /**
  * RegExp for basic auth user/pass
@@ -59,7 +59,7 @@ const controlRE = /[\x00-\x1F\x7F]/
  * password    = *TEXT
  */
 
-const userPassRE = /^([^:]*):(.*)$/
+const userPassRE = /^([^:]*):(.*)$/u
 
 /** @type {typeof import('./types/index').fastifyBasicAuth} */
 async function fastifyBasicAuth (fastify, opts) {


### PR DESCRIPTION
`u` unicode flag is equivalent to `'use strict'` directive in JS

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
